### PR TITLE
Remove redundant assignment

### DIFF
--- a/uniq.js
+++ b/uniq.js
@@ -22,8 +22,8 @@ function unique_pred(list, compare) {
 function unique_eq(list) {
   var ptr = 1
     , len = list.length
-    , a=list[0], b = list[0]
-  for(var i=1; i<len; ++i, b=a) {
+    , a=list[0], b=list[0]
+  for(var i=1; i<len; ++i) {
     b = a
     a = list[i]
     if(a !== b) {


### PR DESCRIPTION
The `b=a` assignment in the for-loop is totally redundant. I have removed it.