### PR TITLE
Fix #15: merge 2 funcs w NO perf hit. Fix 4th test

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,125 @@
+{
+  "name": "uniq",
+  "version": "1.0.1",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "uniq",
+      "version": "1.0.1",
+      "license": "MIT",
+      "devDependencies": {
+        "tape": "^2.12.3"
+      }
+    },
+    "node_modules/deep-equal": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-0.2.2.tgz",
+      "integrity": "sha512-FXgye2Jr6oEk01S7gmSrHrPEQ1ontR7wwl+nYiZ8h4SXlHVm0DYda74BIPcHz2s2qPz4+375IcAz1vsWLwddgQ==",
+      "dev": true
+    },
+    "node_modules/defined": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/defined/-/defined-0.0.0.tgz",
+      "integrity": "sha512-zpqiCT8bODLu3QSmLLic8xJnYWBFjOSu/fBCm189oAiTtPq/PSanNACKZDS7kgSyCJY7P+IcODzlIogBK/9RBg==",
+      "dev": true
+    },
+    "node_modules/glob": {
+      "version": "3.2.11",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
+      "integrity": "sha512-hVb0zwEZwC1FXSKRPFTeOtN7AArJcJlI6ULGLtrstaswKNlrTJqAA+1lYlSUop4vjA423xlBzqfVS3iWGlqJ+g==",
+      "dev": true,
+      "dependencies": {
+        "inherits": "2",
+        "minimatch": "0.3"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/has": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/has/-/has-0.0.1.tgz",
+      "integrity": "sha512-Ulo9uG05SN7r55LqJxpU84yWzVPfJGv+GZSaEnm5mKO/jtwV5KODce9bPEDJh1uoYGJpsy5pKi4dQOdDSFzCvw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true
+    },
+    "node_modules/lru-cache": {
+      "version": "2.7.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
+      "integrity": "sha512-WpibWJ60c3AgAz8a2iYErDrcT2C7OmKnsWhIcHOjkUHFjkXncJhtLxNSqUmxRxRunpb5I8Vprd7aNSd2NtksJQ==",
+      "dev": true
+    },
+    "node_modules/minimatch": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
+      "integrity": "sha512-WFX1jI1AaxNTZVOHLBVazwTWKaQjoykSzCBNXB72vDTCzopQGtyP91tKdFK5cv1+qMwPyiTu1HqUriqplI8pcA==",
+      "deprecated": "Please update to minimatch 3.0.2 or higher to avoid a RegExp DoS issue",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "2",
+        "sigmund": "~1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.12.3",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.3.tgz",
+      "integrity": "sha512-geUvdk7c+eizMNUDkRpW1wJwgfOiOeHbxBR/hLXK1aT6zmVSO0jsQcs7fj6MGw89jC/cjGfLcNOrtMYtGqm81g==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/resumer": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/resumer/-/resumer-0.0.0.tgz",
+      "integrity": "sha512-Fn9X8rX8yYF4m81rZCK/5VmrmsSbqS/i3rDLl6ZZHAXgC2nTAx3dhwG8q8odP/RmdLa2YrybDJaAMg+X1ajY3w==",
+      "dev": true,
+      "dependencies": {
+        "through": "~2.3.4"
+      }
+    },
+    "node_modules/sigmund": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
+      "integrity": "sha512-fCvEXfh6NWpm+YSuY2bpXb/VIihqWA6hLsgboC+0nl71Q7N7o2eaCW8mJa/NLvQhs6jpd3VZV4UiUQlV6+lc8g==",
+      "dev": true
+    },
+    "node_modules/tape": {
+      "version": "2.14.1",
+      "resolved": "https://registry.npmjs.org/tape/-/tape-2.14.1.tgz",
+      "integrity": "sha512-kh37Wjs0ZkZY3Pd73v67GDjOhPFvnu7lHiqAgFfkblD96M4HqrI8ldk4/Q+3h+eKKNvLhZ3kk7ppO+AmYJNthQ==",
+      "dev": true,
+      "dependencies": {
+        "deep-equal": "~0.2.0",
+        "defined": "~0.0.0",
+        "glob": "^3.2.9",
+        "has": "~0.0.1",
+        "inherits": "^2.0.1",
+        "object-inspect": "^1.0.0",
+        "resumer": "~0.0.0",
+        "through": "^2.3.4"
+      },
+      "bin": {
+        "tape": "bin/tape"
+      }
+    },
+    "node_modules/through": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==",
+      "dev": true
+    }
+  }
+}

--- a/test/test.js
+++ b/test/test.js
@@ -5,7 +5,7 @@ require("tape")("unique", function(t) {
   t.equals(unique([1,1,2,3,5,5,7]).join(), [1,2,3,5,7].join())
   t.equals(unique([]).join(), [].join())
   t.equals(unique([1,1,1]).join(), [1].join())
-  t.equals(unique([1,1,1,2,2,2], function(a,b) { return (a^b)&1 }).join(), [2,1].join())
-
+  // t.equals(unique([1,1,1,2,2,2], function(a,b) { return (a^b)&1 }).join(), [2,1].join())
+  t.equals(unique([1,1,1,2,2,2], function(a,b) { return (b-a) }).join(), [2,1].join())
   t.end()
 })

--- a/uniq.js
+++ b/uniq.js
@@ -4,6 +4,11 @@ function unique_pred(list, compare) {
   var ptr = 1
     , len = list.length
     , a = list[0], b = list[0]
+  if(typeof compare !== "function") {
+    compare = function(a, b) {
+      return (a !== b)
+    }
+  }
   for(var i=1; i<len; ++i) {
     b = a
     a = list[i]
@@ -19,39 +24,14 @@ function unique_pred(list, compare) {
   return list
 }
 
-function unique_eq(list) {
-  var ptr = 1
-    , len = list.length
-    , a = list[0], b = list[0]
-  for(var i=1; i<len; ++i) {
-    b = a
-    a = list[i]
-    if(a !== b) {
-      if(i === ptr) {
-        ptr++
-        continue
-      }
-      list[ptr++] = a
-    }
-  }
-  list.length = ptr
-  return list
-}
-
 function unique(list, compare, sorted) {
   if(list.length === 0) {
     return list
   }
-  if(compare) {
-    if(!sorted) {
-      list.sort(compare)
-    }
-    return unique_pred(list, compare)
-  }
   if(!sorted) {
-    list.sort()
+    list.sort(compare)
   }
-  return unique_eq(list)
+  return unique_pred(list, compare)
 }
 
 module.exports = unique


### PR DESCRIPTION
Merged redundant function `unique_eq(list)` into `unique_pred(list, compare)`, without performance hit -- because BEFORE the loop it will now simply update a missing/**invalid** `compare` function with one that has the same logical check currently done by `unique_eq(list)`.

Also, fixed the broken 4th test, so it now works in Node 12+, as recommended by others' PRs:
```
// t.equals(unique([1,1,1,2,2,2], function(a,b) { return (a^b)&1 }).join(), [2,1].join())
t.equals(unique([1,1,1,2,2,2], function(a,b) { return (b-a) }).join(), [2,1].join())
```

NOTE: highly recommend updating `package.json` (and maybe also create a new [release?](https://github.com/mikolalysenko/uniq/releases)) as version **1.1.0** to reduce chance of breaking legacy code that references previous **v1.0.1** by name.

HTH.
